### PR TITLE
Bigger VARCHARs

### DIFF
--- a/src/main/resources/db/2021-10-03.yml
+++ b/src/main/resources/db/2021-10-03.yml
@@ -54,12 +54,12 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: device
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
                   constraints:
                     nullable: false
               - column:
                   name: agent
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
                   constraints:
                     nullable: false
               - column:
@@ -98,7 +98,7 @@ databaseChangeLog:
                     unique: true
               - column:
                   name: name
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
               - column:
                   name: apple_reference
                   type: VARCHAR(45)
@@ -113,7 +113,7 @@ databaseChangeLog:
                   type: VARCHAR(45)
               - column:
                   name: email
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
                   constraints:
                     unique: true
               - column:
@@ -144,23 +144,23 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: name
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
                   constraints:
                     nullable: false
               - column:
                   name: email
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
                   constraints:
                     nullable: false
                     unique: true
               - column:
                   name: website
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
                   constraints:
                     nullable: false
               - column:
                   name: newsfeed
-                  type: VARCHAR(45)
+                  type: VARCHAR(100)
                   constraints:
                     unique: true
               - column:
@@ -170,7 +170,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: postal_code
-                  type: VARCHAR(45)
+                  type: VARCHAR(10)
                   constraints:
                     nullable: false
               - column:


### PR DESCRIPTION
Upped some VARCHAR lengths that made sense to me. Mainly for addressing the `user-device` sent by my iPad Pro and all the Android simulators I tested with to be too long to store in the database, resulting in an error and inability to get past the splash screen on these devices.

Again no migration file so database will be wiped.