### PR TITLE
Hotfix/account references

### DIFF
--- a/src/main/kotlin/org/rescado/server/service/AccountService.kt
+++ b/src/main/kotlin/org/rescado/server/service/AccountService.kt
@@ -83,10 +83,6 @@ class AccountService(
             account.status = Account.Status.ENROLLED
         }
 
-        if (account.status != Account.Status.ANONYMOUS && account.email == null && account.appleReference == null && account.googleReference == null && account.facebookReference == null && account.twitterReference == null) {
-            throw LastReferenceException()
-        }
-
         return accountRepository.save(account)
     }
 

--- a/src/main/kotlin/org/rescado/server/service/AccountService.kt
+++ b/src/main/kotlin/org/rescado/server/service/AccountService.kt
@@ -79,8 +79,13 @@ class AccountService(
             account.avatar = it
         }
 
-        if (account.status == Account.Status.ANONYMOUS)
+        if (account.status == Account.Status.ANONYMOUS && (account.email != null || account.appleReference != null || account.googleReference != null || account.facebookReference != null || account.twitterReference != null)) {
             account.status = Account.Status.ENROLLED
+        }
+
+        if (account.status != Account.Status.ANONYMOUS && account.email == null && account.appleReference == null && account.googleReference == null && account.facebookReference == null && account.twitterReference == null) {
+            throw LastReferenceException()
+        }
 
         return accountRepository.save(account)
     }

--- a/src/main/kotlin/org/rescado/server/service/exception/LastReferenceException.kt
+++ b/src/main/kotlin/org/rescado/server/service/exception/LastReferenceException.kt
@@ -1,3 +1,3 @@
 package org.rescado.server.service.exception
 
-class LastReferenceException(val referenceName: String = "") : IllegalArgumentException("Last reference $referenceName")
+class LastReferenceException(val referenceName: String) : IllegalArgumentException("Last reference $referenceName")

--- a/src/main/kotlin/org/rescado/server/service/exception/LastReferenceException.kt
+++ b/src/main/kotlin/org/rescado/server/service/exception/LastReferenceException.kt
@@ -1,3 +1,3 @@
 package org.rescado.server.service.exception
 
-class LastReferenceException(val referenceName: String) : IllegalArgumentException("Last reference $referenceName")
+class LastReferenceException(val referenceName: String = "") : IllegalArgumentException("Last reference $referenceName")


### PR DESCRIPTION
Vroeger werd je ook `enrolled` als je vb je naam of je avatar wijzigde, maar dan kan je niet meer inloggen eens je token expired. Want enkel `anonymous` kan inloggen zonder e-mail/password of een third-party.