### PR TITLE
Exclude current account in group memberships

### DIFF
--- a/src/main/kotlin/org/rescado/server/controller/dto/ResponseMappers.kt
+++ b/src/main/kotlin/org/rescado/server/controller/dto/ResponseMappers.kt
@@ -125,7 +125,7 @@ fun Membership.toMembershipDTO() = MembershipDTO(
     avatar = account.avatar?.toImageDTO(),
 )
 
-fun Membership.toGroupDTO(exclude: String?) = GroupDTO(
+fun Membership.toGroupDTO(exclude: String? = null) = GroupDTO(
     id = group.id,
     status = status.name,
     members = group.memberships.filterNot { it.account.uuid == exclude }.toMembershipArrayDTO()
@@ -133,7 +133,7 @@ fun Membership.toGroupDTO(exclude: String?) = GroupDTO(
 
 fun List<Membership>.toMembershipArrayDTO() = this.map { it.toMembershipDTO() }
 
-fun Set<Membership>.toGroupArrayDTO(exclude: String?) = this.map { it.toGroupDTO(exclude = exclude) }
+fun Set<Membership>.toGroupArrayDTO(exclude: String? = null) = this.map { it.toGroupDTO(exclude = exclude) }
 // endregion
 // region Session mappers
 

--- a/src/main/kotlin/org/rescado/server/controller/dto/ResponseMappers.kt
+++ b/src/main/kotlin/org/rescado/server/controller/dto/ResponseMappers.kt
@@ -110,7 +110,7 @@ fun Account.toAccountDTO() = AccountDTO(
     twitterLinked = !twitterReference.isNullOrBlank(),
     email = email,
     avatar = avatar?.toImageDTO(),
-    groups = memberships.toGroupArrayDTO(),
+    groups = memberships.toGroupArrayDTO(exclude = uuid),
     shelter = shelter?.toShelterDTO(false),
 )
 
@@ -125,15 +125,15 @@ fun Membership.toMembershipDTO() = MembershipDTO(
     avatar = account.avatar?.toImageDTO(),
 )
 
-fun Membership.toGroupDTO() = GroupDTO(
+fun Membership.toGroupDTO(exclude: String?) = GroupDTO(
     id = group.id,
     status = status.name,
-    members = group.memberships.toMembershipArrayDTO()
+    members = group.memberships.filterNot { it.account.uuid == exclude }.toMembershipArrayDTO()
 )
 
-fun Set<Membership>.toMembershipArrayDTO() = this.map { it.toMembershipDTO() }
+fun List<Membership>.toMembershipArrayDTO() = this.map { it.toMembershipDTO() }
 
-fun Set<Membership>.toGroupArrayDTO() = this.map { it.toGroupDTO() }
+fun Set<Membership>.toGroupArrayDTO(exclude: String?) = this.map { it.toGroupDTO(exclude = exclude) }
 // endregion
 // region Session mappers
 


### PR DESCRIPTION
Niet getest want beetje lastig 😊 maar dit filtert je eigen account uit de lijst van je group memberships.

- `account` had al `uuid` en `groups`
- `groups` is lijst met voor elke group een `id`, jouw `status` in die group en `members`
- `members` is minimale info van elke account in de group: `uuid`, `name`, `status`, `avatar`.

Je eigen entry in de `members` is dus eigenlijk een duplicaat van info die je al krijgt hoger in de JSON response op `GET /account`. Het enige wat niet meer "makkelijk" kan na deze change is som van group members kennen, omdat je nu moet kijken op niveau van `group` of je zelf al deel uitmaakt van die group en eventueel +1 doen. Maar dit maakt het wel makkelijker om in de view in de app vb de avatars of namen van alle members op te lijsten zonder jezelf er eerst uit te moeten filteren (`members.where((member) => member.uuid != account.uuid)`.

`members` is nu dus meer `others` in the group, als je deze change accept. 😊